### PR TITLE
Add README and help listing codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# FPSim
+
+FPSim simulates and measures floating-point assembly routines. It provides a simple model of various CPU cores and assembles small programs to evaluate their latency or throughput.
+
+Dependencies are managed with [uv](https://github.com/astral-sh/uv). Use `uv sync` to create the virtual environment from `pyproject.toml` and `uv.lock` and run the tool with:
+
+```
+uv run python main.py [options] CODE...
+```
+
+Apple M1 hardware is currently the best tested and most fully supported platform.
+

--- a/README.md
+++ b/README.md
@@ -1,12 +1,32 @@
 # FPSim
 
-FPSim simulates and measures floating-point assembly routines. It provides a simple model of various CPU cores and assembles small programs to evaluate their latency or throughput.
+FPSim simulates and measures floating-point assembly routines with a
+focus on floating-point accumulation networks (FPANs). It assembles
+and optimizes small programs to evaluate their latency or throughput,
+either on the user's machine or in a simple CPU simulator.
 
-Dependencies are managed with [uv](https://github.com/astral-sh/uv). Use `uv sync` to create the virtual environment from `pyproject.toml` and `uv.lock` and run the tool with:
+## Getting Started
+
+Dependencies are managed with [uv](https://github.com/astral-sh/uv).
+Use `uv sync` to create a virtual environment and run the tool with:
 
 ```
-uv run python main.py [options] CODE...
+$ uv run python3 main.py ts
+     ts: 15.02 simulated latency, 15.42 measured latency
 ```
 
-Apple M1 hardware is currently the best tested and most fully supported platform.
+This runs a simple TwoSum routine both in simulation and on your
+machine, and then prints its latency.
 
+The Apple M1 is currently the best tested and most fully supported
+platform. Support for x86 is planned but currently incomplete, though
+you can test it by passing `--core CL` and running on an x86 machine.
+
+## Features
+
+FPSim offers a couple of interesting features, including:
+
+- Optimal register allocation using an ILP solver (via PuLP)
+- A fine-grained per-port model of CPU execution
+- Both low-latency and high-throughput TwoSum variants
+- Analytical tuning tools for FPANs, such as finding critical paths

--- a/main.py
+++ b/main.py
@@ -584,11 +584,10 @@ def get_code(name):
 def main():
     import argparse
     # Set up argument parsing
-    codes_help = "\n".join(sorted(CODES.keys()))
     parser = argparse.ArgumentParser(
         description="Simulate CPU performance for TwoSum variants.",
         formatter_class=argparse.RawDescriptionHelpFormatter,
-        epilog=f"Available codes:\n{codes_help}"
+        epilog="Available codes: {}".format(", ".join(sorted(CODES.keys())))
     )
     parser.add_argument('--verbose', action='store_true', help='Enable verbose output')
     parser.add_argument('--core', type=str, default="P", choices=CORES.keys(), help='P-core or E-core')

--- a/main.py
+++ b/main.py
@@ -584,7 +584,12 @@ def get_code(name):
 def main():
     import argparse
     # Set up argument parsing
-    parser = argparse.ArgumentParser(description="Simulate CPU performance for TwoSum variants.")
+    codes_help = "\n".join(sorted(CODES.keys()))
+    parser = argparse.ArgumentParser(
+        description="Simulate CPU performance for TwoSum variants.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=f"Available codes:\n{codes_help}"
+    )
     parser.add_argument('--verbose', action='store_true', help='Enable verbose output')
     parser.add_argument('--core', type=str, default="P", choices=CORES.keys(), help='P-core or E-core')
     parser.add_argument('--instances', type=int, default=1, help='Number of instances')


### PR DESCRIPTION
## Summary
- add minimal project README with uv usage
- show available codes in CLI `--help`

## Testing
- `python -m py_compile main.py fpan.py`
- `python main.py --help` *(fails: ModuleNotFoundError: No module named 'pulp')*

------
https://chatgpt.com/codex/tasks/task_e_6841cd6b0d088331bba78f89e871729b