### PR TITLE
Add SSH run capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ $ uv run python3 main.py ts
 This runs a simple TwoSum routine both in simulation and on your
 machine, and then prints its latency.
 
+To compile and run the measurement on a remote machine, pass
+`--ssh <host>` and FPSim will copy the generated files over SSH,
+compile them there and read the results back.
+
 The Apple M1 is currently the best tested and most fully supported
 platform. Support for x86 is planned but currently incomplete, though
 you can test it by passing `--core CL` and running on an x86 machine.

--- a/main.py
+++ b/main.py
@@ -366,7 +366,7 @@ int main(void) {
 }
 """
 
-def compile_run(code, core):
+def compile_run(code, core, ssh_host=None):
     with tempfile.TemporaryDirectory() as tmpdir:
         asm_file = str(Path(tmpdir) / "routine.s")
         c_file = str(Path(tmpdir) / "routine.c")
@@ -387,11 +387,34 @@ def compile_run(code, core):
             code.to_asm(core.isa, "bench_loop", f)
         with open(c_file, "w") as f:
             f.write(DRIVER)
-        if VERBOSE: print(open(asm_file).read())
-        subprocess.run(["clang", "-c", asm_file, "-o", o_file])
-        #if VERBOSE: subprocess.run(["objdump", "-d", o_file])
-        subprocess.run(["clang", c_file, o_file, "-o", exe_file])
-        res = subprocess.run([exe_file], stdout=subprocess.PIPE)
+        if VERBOSE:
+            print(open(asm_file).read())
+        if ssh_host is None:
+            subprocess.run(["clang", "-c", asm_file, "-o", o_file])
+            subprocess.run(["clang", c_file, o_file, "-o", exe_file])
+            res = subprocess.run([exe_file], stdout=subprocess.PIPE)
+        else:
+            remote_tmp = subprocess.check_output([
+                "ssh", ssh_host, "mktemp", "-d"
+            ]).decode().strip()
+            subprocess.run([
+                "scp", asm_file, f"{ssh_host}:{remote_tmp}/routine.s"
+            ])
+            subprocess.run([
+                "scp", c_file, f"{ssh_host}:{remote_tmp}/routine.c"
+            ])
+            subprocess.run([
+                "ssh", ssh_host,
+                f"clang -c {remote_tmp}/routine.s -o {remote_tmp}/routine.o"
+            ])
+            subprocess.run([
+                "ssh", ssh_host,
+                f"clang {remote_tmp}/routine.c {remote_tmp}/routine.o -o {remote_tmp}/routine"
+            ])
+            res = subprocess.run([
+                "ssh", ssh_host, f"{remote_tmp}/routine"
+            ], stdout=subprocess.PIPE)
+            subprocess.run(["ssh", ssh_host, "rm", "-rf", remote_tmp])
     out = res.stdout.decode("ascii").strip().split()
     assert len(out) == 3 and out[1] == "cycles" and out[2] == "elapsed"
     return float(out[0]) / ASM_ITERATIONS
@@ -425,6 +448,8 @@ def main():
     parser.add_argument('--instances', type=int, default=1, help='Number of instances')
     parser.add_argument('--mode', choices=['simulate', 'measure', 'both'], default='both',
                         help='Run simulation, measurement, or both')
+    parser.add_argument('--ssh', type=str, default=None,
+                        help='Compile and run on the specified SSH host')
     parser.add_argument('codes', nargs=argparse.REMAINDER, help='Functions to simulate')
     args = parser.parse_args()
 
@@ -443,7 +468,7 @@ def main():
             sim = CPU(core, code, verbose=args.verbose).simulate()
             results.append(f"{sim:.2f} simulated latency")
         if args.mode != "simulate":
-            meas = compile_run(code, core)
+            meas = compile_run(code, core, ssh_host=args.ssh)
             results.append(f"{meas:.2f} measured latency")
         print(f"{name:>20}: {', '.join(results)}")
 

--- a/main.py
+++ b/main.py
@@ -398,10 +398,10 @@ def compile_run(code, core, ssh_host=None):
                 "ssh", ssh_host, "mktemp", "-d"
             ]).decode().strip()
             subprocess.run([
-                "scp", asm_file, f"{ssh_host}:{remote_tmp}/routine.s"
+                "scp", "-q", asm_file, f"{ssh_host}:{remote_tmp}/routine.s"
             ])
             subprocess.run([
-                "scp", c_file, f"{ssh_host}:{remote_tmp}/routine.c"
+                "scp", "-q", c_file, f"{ssh_host}:{remote_tmp}/routine.c"
             ])
             subprocess.run([
                 "ssh", ssh_host,


### PR DESCRIPTION
## Summary
- allow `compile_run` to build and execute code remotely using `--ssh`
- expose new CLI option `--ssh`
- mention `--ssh` in documentation

## Testing
- `python3 -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_686d5e05d0c48331a6947bc9f437b1a1