### PR TITLE
Add vector-prefixed ARM instructions

### DIFF
--- a/cores.py
+++ b/cores.py
@@ -18,6 +18,8 @@ PCORE = Core(ARM, {
     "fabs": (2, [11, 12, 13, 14]),
     "fcmp": (2, [11]),
     "fcsel": (2, [13, 14]),
+    "fcmge": (2, [11, 12, 13, 14]),
+    "bsl": (2, [11, 12, 13, 14]),
 }, priority=[12, 13, 14, 11])
 
 ECORE = Core(ARM, {
@@ -26,6 +28,8 @@ ECORE = Core(ARM, {
     "fabs": (2, [6, 7]),
     "fcmp": (2, [6]),
     "fcsel": (2, [6, 7]),
+    "fcmge": (2, [6, 7]),
+    "bsl": (2, [6, 7]),
 }, priority=[7, 6])
 
 # Coffee Lake


### PR DESCRIPTION
## Summary
- extend ISA prefix handling to support multiple register styles
- add `fcmge` and `bsl` instructions for ARM
- generate assembly using new prefix rules
- include M1 port/latency entries for the new instructions
- incorporate feedback from reviewer

## Testing
- `python3 -m py_compile assembler.py cores.py main.py fpan.py`
- `python3 main.py ts` *(fails: ModuleNotFoundError: No module named 'pulp')*

------
https://chatgpt.com/codex/tasks/task_e_686d6963bb3483318261b974b7b7d98b